### PR TITLE
Fix the yaml to remove circular dependency

### DIFF
--- a/infra/lightsail-cms.yaml
+++ b/infra/lightsail-cms.yaml
@@ -33,6 +33,7 @@ Resources:
 
   CmsBucketPolicy:
     Type: AWS::S3::BucketPolicy
+    DependsOn: CmsDistribution
     Properties:
       Bucket: !Ref CmsBucket
       PolicyDocument:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes CloudFormation resource ordering to prevent a circular/creation-time dependency.
> 
> - In `infra/lightsail-cms.yaml`, adds `DependsOn: CmsDistribution` to `CmsBucketPolicy` so the S3 bucket policy is created after the CloudFront distribution it references (`AWS:SourceArn`), ensuring proper deployment sequencing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7698a1e8aa59662148e6abd2ca6a0bbee107a2e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->