### PR TITLE
add pm2 install to build

### DIFF
--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -214,6 +214,13 @@ jobs:
           set -euo pipefail
           cd /opt/heron-cms
           
+          # Ensure pm2 is available (UserData installs it; PATH may omit npm global bin in non-interactive SSH)
+          export PATH="/usr/local/bin:/usr/bin:$PATH"
+          if ! command -v pm2 >/dev/null 2>&1; then
+            echo "Installing pm2..."
+            sudo npm install -g pm2
+          fi
+          
           # Ensure pm2 resurrects on reboot (idempotent)
           sudo env PATH=$PATH pm2 startup systemd -u ubuntu --hp /home/ubuntu 2>/dev/null || true
           

--- a/heron/app/feed.xml/route.ts
+++ b/heron/app/feed.xml/route.ts
@@ -3,8 +3,8 @@ import { getAllPosts } from "@/services/posts";
 import { serializePost } from "@/lib/serializers";
 
 const baseUrl =
-  process.env.NEXTAUTH_URL ||
-  process.env.VERCEL_URL ||
+  process.env.NEXTAUTH_URL?.trim() ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000") ||
   "http://localhost:3000";
 
 function escapeXml(s: string): string {

--- a/heron/app/layout.tsx
+++ b/heron/app/layout.tsx
@@ -4,8 +4,9 @@ import Navigation from "@/components/Navigation";
 import Providers from "@/app/providers";
 
 const baseUrl =
-  process.env.NEXTAUTH_URL ||
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
+  process.env.NEXTAUTH_URL?.trim() ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000") ||
+  "http://localhost:3000";
 
 export const metadata = {
   title: "Heron",

--- a/heron/app/robots.ts
+++ b/heron/app/robots.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from "next";
 
 const baseUrl =
-  process.env.NEXTAUTH_URL ||
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
+  process.env.NEXTAUTH_URL?.trim() ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000") ||
+  "http://localhost:3000";
 
 export default function robots(): MetadataRoute.Robots {
   const root = baseUrl.replace(/\/+$/, "");

--- a/heron/app/sitemap.ts
+++ b/heron/app/sitemap.ts
@@ -3,8 +3,9 @@ import { getAllPosts } from "@/services/posts";
 import { getAllAlbums } from "@/services/albums";
 
 const baseUrl =
-  process.env.NEXTAUTH_URL ||
-  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000");
+  process.env.NEXTAUTH_URL?.trim() ||
+  (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:3000") ||
+  "http://localhost:3000";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const root = baseUrl.replace(/\/+$/, "");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are small and localized to CI deploy scripting and URL construction; main risk is environment-specific behavior if `NEXTAUTH_URL`/`VERCEL_URL` are misconfigured.
> 
> **Overview**
> **Deployment:** Updates the Lightsail GitHub Actions restart step to explicitly set PATH and *install `pm2` on-demand* when it’s not found, reducing failures in non-interactive SSH sessions.
> 
> **URLs/SEO:** Hardens `baseUrl` resolution across `layout.tsx`, `feed.xml`, `robots.ts`, and `sitemap.ts` by trimming `NEXTAUTH_URL`, properly prefixing `VERCEL_URL` with `https://`, and falling back to `http://localhost:3000` when neither is set, preventing incorrect metadataBase/feed/sitemap links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a39d5bbe915e1f7336e291bcf755d6b0f663ab4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->