### PR TITLE
Update to use letsencrypt and serve website on 443

### DIFF
--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -240,7 +240,7 @@ jobs:
           SITE_DOMAIN='${SITE_DOMAIN}'
           LETSENCRYPT_EMAIL='${LETSENCRYPT_EMAIL}'
 
-          sudo mkdir -p "\$WEBROOT"
+          sudo mkdir -p "\$WEBROOT/.well-known/acme-challenge"
           sudo chown -R bitnami:bitnami "\$WEBROOT"
 
           # Prefer Let's Encrypt cert paths when they exist
@@ -257,8 +257,8 @@ jobs:
           sudo tee "\$VHOST" > /dev/null <<APACHE
           <VirtualHost *:80>
             ServerName \${SITE_DOMAIN}
-            Alias /.well-known/acme-challenge \$WEBROOT
-            <Directory \$WEBROOT>
+            Alias /.well-known/acme-challenge \$WEBROOT/.well-known/acme-challenge
+            <Directory \$WEBROOT/.well-known/acme-challenge>
               Require all granted
             </Directory>
             ProxyPreserveHost On

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -312,6 +312,6 @@ jobs:
             fi
             # Ensure renewal runs twice daily and restarts Apache after renew
             RENEW_HOOK='/opt/bitnami/ctlscript.sh restart apache 2>/dev/null || systemctl restart apache2'
-            (sudo crontab -l 2>/dev/null | grep -v certbot; echo "0 0,12 * * * certbot renew -q --deploy-hook \"\$RENEW_HOOK\" 2>/dev/null") | sudo crontab - 2>/dev/null || true
+            (sudo crontab -l 2>/dev/null | grep -v certbot; echo "0 0,12 * * * certbot renew -q --deploy-hook \"$RENEW_HOOK\" 2>/dev/null") | sudo crontab - 2>/dev/null || true
           fi
           PROXY

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -265,10 +265,10 @@ jobs:
             <Directory \$WEBROOT/.well-known/acme-challenge>
               Require all granted
             </Directory>
-            ProxyPreserveHost On
-            ProxyPass /.well-known/acme-challenge !
-            ProxyPass / http://127.0.0.1:3000/
-            ProxyPassReverse / http://127.0.0.1:3000/
+            # Redirect all traffic to HTTPS except ACME challenges
+            RewriteEngine On
+            RewriteCond %{REQUEST_URI} !^/.well-known/acme-challenge/
+            RewriteRule ^(.*)$ https://%{HTTP_HOST}\$1 [R=301,L]
           </VirtualHost>
           <VirtualHost *:443>
             ServerName \${SITE_DOMAIN}

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -228,22 +228,86 @@ jobs:
           echo "✓ Services running"
           SVC
 
-      - name: Configure Apache reverse proxy
+      - name: Configure Apache reverse proxy and Let's Encrypt
+        env:
+          SITE_DOMAIN: ${{ secrets.ROUTE53_RECORD_NAME }}
+          LETSENCRYPT_EMAIL: ${{ secrets.LETSENCRYPT_EMAIL }}
         run: |
-          ssh -F ssh_config lightsail "bash -s" <<'PROXY'
+          ssh -F ssh_config lightsail "bash -s" <<PROXY
           set -euo pipefail
           VHOST="/opt/bitnami/apache/conf/vhosts/heron-cms-proxy.conf"
-          sudo tee "$VHOST" > /dev/null <<'APACHE'
+          WEBROOT="/var/lib/letsencrypt-webroot"
+          SITE_DOMAIN='${SITE_DOMAIN}'
+          LETSENCRYPT_EMAIL='${LETSENCRYPT_EMAIL}'
+
+          sudo mkdir -p "\$WEBROOT"
+          sudo chown -R bitnami:bitnami "\$WEBROOT"
+
+          # Prefer Let's Encrypt cert paths when they exist
+          LE_CERT="/etc/letsencrypt/live/\${SITE_DOMAIN}/fullchain.pem"
+          LE_KEY="/etc/letsencrypt/live/\${SITE_DOMAIN}/privkey.pem"
+          if [ -f "\$LE_CERT" ] && [ -f "\$LE_KEY" ]; then
+            CERT_FILE="\$LE_CERT"
+            KEY_FILE="\$LE_KEY"
+          else
+            CERT_FILE="/opt/bitnami/apache/conf/bitnami/certs/server.crt"
+            KEY_FILE="/opt/bitnami/apache/conf/bitnami/certs/server.key"
+          fi
+
+          sudo tee "\$VHOST" > /dev/null <<APACHE
           <VirtualHost *:80>
+            ServerName \${SITE_DOMAIN}
+            Alias /.well-known/acme-challenge \$WEBROOT
+            <Directory \$WEBROOT>
+              Require all granted
+            </Directory>
+            ProxyPreserveHost On
+            ProxyPass /.well-known/acme-challenge !
+            ProxyPass / http://127.0.0.1:3000/
+            ProxyPassReverse / http://127.0.0.1:3000/
+          </VirtualHost>
+          <VirtualHost *:443>
+            ServerName \${SITE_DOMAIN}
+            SSLEngine on
+            SSLCertificateFile "\$CERT_FILE"
+            SSLCertificateKeyFile "\$KEY_FILE"
             ProxyPreserveHost On
             ProxyPass / http://127.0.0.1:3000/
             ProxyPassReverse / http://127.0.0.1:3000/
           </VirtualHost>
           APACHE
+
           if [ -x /opt/bitnami/ctlscript.sh ]; then
             sudo /opt/bitnami/ctlscript.sh restart apache
           else
             sudo systemctl restart apache2 2>/dev/null || sudo systemctl restart httpd 2>/dev/null || true
           fi
-          echo "✓ Apache proxy configured (80 -> 3000)"
+          echo "✓ Apache proxy configured (80 + 443 -> 3000)"
+
+          # Obtain or renew Let's Encrypt certificate when domain and email are set
+          if [ -n "\$SITE_DOMAIN" ] && [ -n "\$LETSENCRYPT_EMAIL" ]; then
+            if ! command -v certbot >/dev/null 2>&1; then
+              echo "Installing certbot..."
+              sudo apt-get update -qq -y
+              sudo apt-get install -y -qq certbot
+            fi
+            if sudo certbot certonly --webroot -w "\$WEBROOT" -d "\$SITE_DOMAIN" \
+              --non-interactive --agree-tos --email "\$LETSENCRYPT_EMAIL" \
+              --keep-until-expiring 2>/dev/null; then
+              echo "✓ Let's Encrypt certificate obtained or already valid"
+              # Re-write vhost with LE paths and restart
+              sudo sed -i "s|SSLCertificateFile .*|SSLCertificateFile \$LE_CERT|" "\$VHOST"
+              sudo sed -i "s|SSLCertificateKeyFile .*|SSLCertificateKeyFile \$LE_KEY|" "\$VHOST"
+              if [ -x /opt/bitnami/ctlscript.sh ]; then
+                sudo /opt/bitnami/ctlscript.sh restart apache
+              else
+                sudo systemctl restart apache2 2>/dev/null || sudo systemctl restart httpd 2>/dev/null || true
+              fi
+            else
+              echo "⚠ Certbot did not obtain a certificate (DNS may not point here yet); using existing or self-signed cert"
+            fi
+            # Ensure renewal runs twice daily and restarts Apache after renew
+            RENEW_HOOK='/opt/bitnami/ctlscript.sh restart apache 2>/dev/null || systemctl restart apache2'
+            (sudo crontab -l 2>/dev/null | grep -v certbot; echo "0 0,12 * * * certbot renew -q --deploy-hook \"\$RENEW_HOOK\" 2>/dev/null") | sudo crontab - 2>/dev/null || true
+          fi
           PROXY

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -240,6 +240,10 @@ jobs:
           SITE_DOMAIN='${SITE_DOMAIN}'
           LETSENCRYPT_EMAIL='${LETSENCRYPT_EMAIL}'
 
+          if [ -z "\$SITE_DOMAIN" ]; then
+            echo "SITE_DOMAIN is empty; skipping Apache reverse proxy and Let's Encrypt configuration."
+            exit 0
+          fi
           sudo mkdir -p "\$WEBROOT/.well-known/acme-challenge"
           sudo chown -R bitnami:bitnami "\$WEBROOT"
 

--- a/README.md
+++ b/README.md
@@ -110,3 +110,7 @@ Deployments are automated via GitHub Actions to AWS Lightsail. The pipeline buil
 - **Workflow**: `.github/workflows/deploy-lightsail.yml`
 - **Infrastructure**: `infra/lightsail-cms.yaml` (Lightsail instance, S3, CloudFront)
 - **Local dev** uses Docker Compose and MinIO only; production does not run the app in Docker.
+
+### HTTPS with Let's Encrypt
+
+If the repo secrets **`ROUTE53_RECORD_NAME`** (your domain) and **`LETSENCRYPT_EMAIL`** (e.g. `admin@yourdomain.com`) are set, each deploy will attempt to obtain or renew a Let's Encrypt certificate and configure Apache to use it. Certbot runs on the instance and a cron job renews the cert twice daily. Ensure your domain’s DNS already points to the Lightsail static IP before the first deploy so ACME validation can succeed.


### PR DESCRIPTION
Add virtual host for 443 to reverse proxy nodejs app, add lets encrypt support to get cert and autorenew