### PR TITLE
Deploy: Lightsail Node.js blueprint + CI rsync (no server Docker)

### DIFF
--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -206,3 +206,6 @@ jobs:
           LETSENCRYPT_EMAIL: ${{ secrets.LETSENCRYPT_EMAIL }}
         run: |
           ssh -F ssh_config lightsail "SITE_DOMAIN='${{ secrets.ROUTE53_RECORD_NAME }}' LETSENCRYPT_EMAIL='${{ secrets.LETSENCRYPT_EMAIL }}' bash -c 'cd /opt/heron-cms && bash scripts/deploy-configure-apache.sh'"
+
+      - name: Install weekly SQLite backup cron
+        run: ssh -F ssh_config lightsail "cd /opt/heron-cms && bash scripts/deploy-install-db-backup-cron.sh"

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -11,7 +11,10 @@ jobs:
     environment: production
     permissions:
       contents: read
-      packages: write
+
+    env:
+      # Default bitnami until migrated; set secret LIGHTSAIL_SSH_USER=ubuntu on Lightsail Node.js VM
+      LIGHTSAIL_SSH_USER: ${{ secrets.LIGHTSAIL_SSH_USER || 'bitnami' }}
 
     steps:
       - name: Checkout
@@ -24,7 +27,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      # Use Node 24 to match Bitnami/Lightsail server (better-sqlite3 is native and must match)
+      # Node 24 — build on Linux CI; native modules must match the Lightsail VM (glibc)
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -56,6 +59,10 @@ jobs:
           # Site title (GitHub Environment variable, not a secret)
           SITE_TITLE: ${{ vars.SITE_TITLE }}
         run: npm run build
+        working-directory: heron
+
+      - name: Rebuild native modules for Linux deploy target
+        run: npm rebuild better-sqlite3
         working-directory: heron
 
       - name: Deploy CloudFormation
@@ -127,7 +134,7 @@ jobs:
           cat > ssh_config <<SSH
           Host lightsail
             HostName $LIGHTSAIL_HOST
-            User bitnami
+            User ${{ env.LIGHTSAIL_SSH_USER }}
             IdentityFile $(pwd)/lightsail.key
             StrictHostKeyChecking no
             ServerAliveInterval 60
@@ -184,7 +191,8 @@ jobs:
           ssh -F ssh_config lightsail "bash -s" <<'DB'
           set -euo pipefail
           cd /opt/heron-cms
-          export PATH="/opt/bitnami/node/bin:/usr/local/bin:/usr/bin:$PATH"
+          source scripts/deploy-runtime.sh
+          deploy_runtime_detect
           set -a; [ -f .env ] && . ./.env; set +a
           node scripts/deploy-db.cjs
           DB

--- a/README.md
+++ b/README.md
@@ -105,12 +105,22 @@ graph TD
 
 ## 🚢 Deployment
 
-Deployments are automated via GitHub Actions to AWS Lightsail. The pipeline builds the Next.js app as a standalone output, rsyncs artifacts to the instance, and runs the app with pm2. The database lives in `/var/lib/heron-cms/data` on the server so it is not overwritten on deploy.
+Deployments are automated via GitHub Actions to AWS Lightsail. The pipeline builds the Next.js app on Linux (Node 24), rebuilds `better-sqlite3` for the VM, rsyncs the standalone output to `/opt/heron-cms`, and runs the app with **pm2**. The database lives in `/var/lib/heron-cms/data` on the server so it is not overwritten on deploy.
+
+Production uses an **AWS Lightsail Node.js blueprint** (not Bitnami; see [Bitnami deprecation](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-faq-bitnami-blueprints.html)). You deploy **your own app** on top of that image—there is no custom Lightsail blueprint upload. **Docker is not required on the server** (suitable for nano instances).
 
 - **Workflow**: `.github/workflows/deploy-lightsail.yml`
 - **Infrastructure**: `infra/lightsail-cms.yaml` (Lightsail instance, S3, CloudFront)
-- **Local dev** uses Docker Compose and MinIO only; production does not run the app in Docker.
+- **Migration**: `docs/DEPLOY_MIGRATION.md`
+- **Local dev** uses Docker Compose and MinIO only.
+
+### GitHub secrets
+
+| Secret | Notes |
+|--------|--------|
+| `LIGHTSAIL_SSH_USER` | `ubuntu` on Lightsail Node.js; `bitnami` until you migrate (workflow default) |
+| `ROUTE53_RECORD_NAME`, `LETSENCRYPT_EMAIL` | HTTPS via Apache + certbot on the instance |
 
 ### HTTPS with Let's Encrypt
 
-If the repo secrets **`ROUTE53_RECORD_NAME`** (your domain) and **`LETSENCRYPT_EMAIL`** (e.g. `admin@yourdomain.com`) are set, each deploy will attempt to obtain or renew a Let's Encrypt certificate and configure Apache to use it. Certbot runs on the instance and a cron job renews the cert twice daily. Ensure your domain’s DNS already points to the Lightsail static IP before the first deploy so ACME validation can succeed.
+If **`ROUTE53_RECORD_NAME`** and **`LETSENCRYPT_EMAIL`** are set, each deploy configures Apache as a reverse proxy to port 3000 and runs certbot (webroot). Ensure DNS points at the Lightsail static IP before the first certificate request.

--- a/README.md
+++ b/README.md
@@ -124,3 +124,19 @@ Production uses an **AWS Lightsail Node.js blueprint** (not Bitnami; see [Bitnam
 ### HTTPS with Let's Encrypt
 
 If **`ROUTE53_RECORD_NAME`** and **`LETSENCRYPT_EMAIL`** are set, each deploy configures Apache as a reverse proxy to port 3000 and runs certbot (webroot). Ensure DNS points at the Lightsail static IP before the first certificate request.
+
+### SQLite backups (S3)
+
+Each deploy installs a **weekly** cron job (Sunday 03:15 UTC) that:
+
+1. Creates a consistent SQLite backup (WAL-safe) via `better-sqlite3`
+2. Uploads `backups/cms-db/cms-YYYY-MM-DD.db.gz` to your CMS S3 bucket
+3. Deletes older backups, keeping the **8 most recent weeks** by default
+
+Manual run on the server:
+
+```bash
+cd /opt/heron-cms && set -a && . ./.env && set +a && node scripts/backup-cms-db.cjs
+```
+
+Optional env vars in `.env`: `CMS_DB_BACKUP_RETAIN_WEEKS`, `CMS_DB_BACKUP_PREFIX`. Logs: `/var/log/heron-cms-db-backup.log`.

--- a/docs/DEPLOY_MIGRATION.md
+++ b/docs/DEPLOY_MIGRATION.md
@@ -1,0 +1,42 @@
+# Migrating from Bitnami to Lightsail Node.js (rsync + pm2)
+
+Heron production deploys **your built app** on top of an AWS Lightsail blueprint. You do not upload a custom Lightsail blueprint; CI rsyncs the Next.js standalone output and pm2 runs `server.js`.
+
+## Why migrate
+
+Bitnami Node.js on Lightsail is deprecated ([FAQ](https://docs.aws.amazon.com/lightsail/latest/userguide/amazon-lightsail-faq-bitnami-blueprints.html)). New instances should use the **Lightsail**-packaged **Node.js** blueprint (vendor shows as **Lightsail** in the console, not Bitnami).
+
+## What changed in this repo
+
+- `heron/scripts/deploy-runtime.sh` — detects Bitnami vs Lightsail paths on the server
+- Deploy scripts work on **both** stacks during cutover
+- GitHub Actions: optional `LIGHTSAIL_SSH_USER` secret (default `ubuntu` for Lightsail; use `bitnami` until you migrate)
+- CI runs `npm rebuild better-sqlite3` so native modules match the Linux VM
+
+## Cutover steps (nano instance, no Docker)
+
+1. **Snapshot** the current production instance.
+2. In Lightsail console, create a new instance:
+   - Blueprint: **Node.js** (vendor **Lightsail**)
+   - Bundle: same as today (e.g. nano)
+   - Same SSH key pair as CloudFormation / GitHub secrets
+3. Copy data from old host:
+   ```bash
+   rsync -avz -e "ssh -i lightsail.key" bitnami@OLD_IP:/var/lib/heron-cms/data/ ubuntu@NEW_IP:/var/lib/heron-cms/data/
+   ```
+4. In GitHub **production** environment, set secret `LIGHTSAIL_SSH_USER` to `ubuntu` (or rely on workflow default after merge).
+5. **Attach the static IP** to the new instance (or let the deploy workflow update Route53 to the new IP).
+6. Run **Deploy Lightsail CMS** workflow on `main`.
+7. Verify HTTPS, admin login, uploads. Decommission the old instance after soak.
+
+## CloudFormation note
+
+Updating `LightsailBlueprintId` on an **existing** `AWS::Lightsail::Instance` may **replace** the instance. Prefer creating the new VM in the console, then updating DNS/static IP, rather than forcing a blueprint change on the live stack.
+
+## Verify blueprint ID
+
+```bash
+aws lightsail get-blueprints --query "blueprints[?contains(name, 'Node')].[blueprintId,name,isActive]" --output table
+```
+
+Use the active Node.js blueprint whose vendor is Lightsail when launching new instances.

--- a/docs/DEPLOY_MIGRATION.md
+++ b/docs/DEPLOY_MIGRATION.md
@@ -40,3 +40,7 @@ aws lightsail get-blueprints --query "blueprints[?contains(name, 'Node')].[bluep
 ```
 
 Use the active Node.js blueprint whose vendor is Lightsail when launching new instances.
+
+## SQLite backups
+
+Production deploys install a weekly cron that uploads a gzipped DB backup to `s3://<CMS_BUCKET>/backups/cms-db/`. After migration, run a deploy (or install cron manually) so the new instance has the job. Restore by downloading a `.db.gz`, `gunzip`, and replacing `cms.db` while the app is stopped.

--- a/docs/superpowers/specs/2026-05-30-lightsail-blueprint-rsync-deploy.md
+++ b/docs/superpowers/specs/2026-05-30-lightsail-blueprint-rsync-deploy.md
@@ -1,0 +1,13 @@
+# Lightsail blueprint + CI rsync deploy (approved)
+
+**Status:** Implemented in `deploy/lightsail-nodejs-blueprint`  
+**Date:** 2026-05-30
+
+## Summary
+
+- **Host:** AWS Lightsail **Node.js** blueprint (Lightsail vendor), `nano_3_0`, no server Docker
+- **App:** CI builds Next.js standalone on Node 24; `npm rebuild better-sqlite3`; rsync + pm2
+- **Scripts:** `deploy-runtime.sh` auto-detects Bitnami vs Lightsail Apache/Node paths
+- **SSH:** `LIGHTSAIL_SSH_USER` secret (`ubuntu` after migration; default `bitnami` for existing prod)
+
+See `docs/DEPLOY_MIGRATION.md` for cutover steps.

--- a/heron/scripts/backup-cms-db.cjs
+++ b/heron/scripts/backup-cms-db.cjs
@@ -1,0 +1,150 @@
+/**
+ * Backup CMS SQLite DB to S3 (gzip), prune backups older than retention window.
+ * Requires: CMS_DB_PATH, S3_BUCKET, S3_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+ * Optional: CMS_DB_BACKUP_PREFIX (default backups/cms-db/), CMS_DB_BACKUP_RETAIN_WEEKS (default 8)
+ */
+const Database = require("better-sqlite3");
+const {
+  S3Client,
+  PutObjectCommand,
+  ListObjectsV2Command,
+  DeleteObjectsCommand
+} = require("@aws-sdk/client-s3");
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+const { pipeline } = require("stream/promises");
+
+const dbPath = process.env.CMS_DB_PATH || path.join(process.cwd(), "data", "cms.db");
+const bucket = process.env.S3_BUCKET;
+const region = process.env.S3_REGION || "us-east-1";
+const prefix = (process.env.CMS_DB_BACKUP_PREFIX || "backups/cms-db/").replace(/\/?$/, "/");
+const retainWeeks = Math.max(1, parseInt(process.env.CMS_DB_BACKUP_RETAIN_WEEKS || "8", 10));
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`Missing required env: ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function backupKeyForDate(dateStr) {
+  return `${prefix}cms-${dateStr}.db.gz`;
+}
+
+function parseDateFromKey(key) {
+  const match = key.match(/cms-(\d{4}-\d{2}-\d{2})\.db\.gz$/);
+  return match ? match[1] : null;
+}
+
+async function gzipFile(inputPath, outputPath) {
+  await pipeline(
+    fs.createReadStream(inputPath),
+    zlib.createGzip(),
+    fs.createWriteStream(outputPath)
+  );
+}
+
+async function createSqliteBackup(sourcePath, destPath) {
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`Database not found: ${sourcePath}`);
+  }
+  const db = new Database(sourcePath, { readonly: true });
+  try {
+    await db.backup(destPath);
+  } finally {
+    db.close();
+  }
+}
+
+function createS3Client() {
+  const endpoint = process.env.S3_ENDPOINT_URL;
+  const forcePathStyle = process.env.S3_FORCE_PATH_STYLE === "true";
+  return new S3Client({
+    region,
+    endpoint: endpoint || undefined,
+    forcePathStyle: endpoint ? forcePathStyle : undefined,
+    credentials: {
+      accessKeyId: requireEnv("AWS_ACCESS_KEY_ID"),
+      secretAccessKey: requireEnv("AWS_SECRET_ACCESS_KEY")
+    }
+  });
+}
+
+async function uploadBackup(client, localGzPath, key) {
+  const body = fs.readFileSync(localGzPath);
+  await client.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: "application/gzip",
+      Metadata: {
+        source: "heron-cms",
+        "db-path": dbPath
+      }
+    })
+  );
+  console.log(`Uploaded s3://${bucket}/${key} (${body.length} bytes)`);
+}
+
+async function pruneOldBackups(client) {
+  const listed = await client.send(
+    new ListObjectsV2Command({
+      Bucket: bucket,
+      Prefix: prefix
+    })
+  );
+  const objects = (listed.Contents || [])
+    .map((o) => ({ key: o.Key, date: parseDateFromKey(o.Key || "") }))
+    .filter((o) => o.date)
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+
+  const toDelete = objects.slice(retainWeeks);
+  if (toDelete.length === 0) {
+    console.log(`Retention: keeping all ${objects.length} backup(s) (limit ${retainWeeks} weeks).`);
+    return;
+  }
+
+  await client.send(
+    new DeleteObjectsCommand({
+      Bucket: bucket,
+      Delete: {
+        Objects: toDelete.map((o) => ({ Key: o.key })),
+        Quiet: true
+      }
+    })
+  );
+  console.log(`Retention: deleted ${toDelete.length} backup(s) older than ${retainWeeks} newest weeks.`);
+  for (const o of toDelete) {
+    console.log(`  removed ${o.key}`);
+  }
+}
+
+async function main() {
+  requireEnv("S3_BUCKET");
+  const dateStr = new Date().toISOString().slice(0, 10);
+  const tmpDir = fs.mkdtempSync(path.join("/tmp", "heron-cms-backup-"));
+  const rawBackup = path.join(tmpDir, "cms.db");
+  const gzBackup = path.join(tmpDir, "cms.db.gz");
+  const s3Key = backupKeyForDate(dateStr);
+
+  try {
+    console.log("Backing up DB:", dbPath);
+    await createSqliteBackup(dbPath, rawBackup);
+    await gzipFile(rawBackup, gzBackup);
+    const client = createS3Client();
+    await uploadBackup(client, gzBackup, s3Key);
+    await pruneOldBackups(client);
+    console.log("backup-cms-db complete.");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error("backup-cms-db failed:", err);
+  process.exit(1);
+});

--- a/heron/scripts/deploy-configure-apache.sh
+++ b/heron/scripts/deploy-configure-apache.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # Configure Apache reverse proxy and Let's Encrypt. Requires SITE_DOMAIN (and optionally LETSENCRYPT_EMAIL) in env.
 set -euo pipefail
-VHOST="/opt/bitnami/apache/conf/vhosts/heron-cms-proxy.conf"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy-runtime.sh
+source "$SCRIPT_DIR/deploy-runtime.sh"
+deploy_runtime_detect
+
 WEBROOT="/var/lib/letsencrypt-webroot"
 
 if [ -z "${SITE_DOMAIN:-}" ]; then
@@ -9,36 +14,45 @@ if [ -z "${SITE_DOMAIN:-}" ]; then
   exit 0
 fi
 
+if [ "$DEPLOY_VENDOR" = lightsail ]; then
+  if ! command -v apache2 >/dev/null 2>&1; then
+    echo "Installing apache2..."
+    sudo apt-get update -qq -y
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq apache2
+  fi
+  sudo a2enmod proxy proxy_http ssl rewrite headers 2>/dev/null || true
+fi
+
 sudo mkdir -p "$WEBROOT/.well-known/acme-challenge"
-sudo chown -R bitnami:bitnami "$WEBROOT"
+sudo chown -R "$DEPLOY_USER:$DEPLOY_USER" "$WEBROOT"
 
 LE_CERT="/etc/letsencrypt/live/${SITE_DOMAIN}/fullchain.pem"
 LE_KEY="/etc/letsencrypt/live/${SITE_DOMAIN}/privkey.pem"
-BITNAMI_CERT_DIR="/opt/bitnami/apache/conf/bitnami/certs"
-BITNAMI_CERT="$BITNAMI_CERT_DIR/server.crt"
-BITNAMI_KEY="$BITNAMI_CERT_DIR/server.key"
+FALLBACK_CERT="$DEPLOY_APACHE_CERT_DIR/server.crt"
+FALLBACK_KEY="$DEPLOY_APACHE_CERT_DIR/server.key"
+
 if [ -f "$LE_CERT" ] && [ -f "$LE_KEY" ]; then
   CERT_FILE="$LE_CERT"
   KEY_FILE="$LE_KEY"
 else
-  CERT_FILE="$BITNAMI_CERT"
-  KEY_FILE="$BITNAMI_KEY"
-  if [ ! -f "$BITNAMI_CERT" ] || [ ! -f "$BITNAMI_KEY" ]; then
+  CERT_FILE="$FALLBACK_CERT"
+  KEY_FILE="$FALLBACK_KEY"
+  if [ ! -f "$FALLBACK_CERT" ] || [ ! -f "$FALLBACK_KEY" ]; then
     echo "Creating self-signed cert for Apache 443..."
-    sudo mkdir -p "$BITNAMI_CERT_DIR"
+    sudo mkdir -p "$DEPLOY_APACHE_CERT_DIR"
     sudo openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-      -keyout "$BITNAMI_CERT_DIR/server.key" -out "$BITNAMI_CERT_DIR/server.crt" \
+      -keyout "$FALLBACK_KEY" -out "$FALLBACK_CERT" \
       -subj "/CN=${SITE_DOMAIN}/O=Heron CMS"
-    sudo chmod 644 "$BITNAMI_CERT_DIR/server.crt"
-    sudo chmod 600 "$BITNAMI_CERT_DIR/server.key"
+    sudo chmod 644 "$FALLBACK_CERT"
+    sudo chmod 600 "$FALLBACK_KEY"
   fi
 fi
 
-sudo tee "$VHOST" > /dev/null <<APACHE
+sudo tee "$DEPLOY_VHOST_PATH" > /dev/null <<APACHE
 <VirtualHost *:80>
   ServerName ${SITE_DOMAIN}
-  Alias /.well-known/acme-challenge $WEBROOT/.well-known/acme-challenge
-  <Directory $WEBROOT/.well-known/acme-challenge>
+  Alias /.well-known/acme-challenge ${WEBROOT}/.well-known/acme-challenge
+  <Directory ${WEBROOT}/.well-known/acme-challenge>
     Require all granted
   </Directory>
   RewriteEngine On
@@ -48,32 +62,29 @@ sudo tee "$VHOST" > /dev/null <<APACHE
 <VirtualHost *:443>
   ServerName ${SITE_DOMAIN}
   SSLEngine on
-  SSLCertificateFile "$CERT_FILE"
-  SSLCertificateKeyFile "$KEY_FILE"
+  SSLCertificateFile "${CERT_FILE}"
+  SSLCertificateKeyFile "${KEY_FILE}"
   ProxyPreserveHost On
   ProxyPass / http://127.0.0.1:3000/
   ProxyPassReverse / http://127.0.0.1:3000/
 </VirtualHost>
 APACHE
 
-if [ -x /opt/bitnami/apache/bin/apachectl ]; then
+if [ "$DEPLOY_VENDOR" = lightsail ]; then
+  sudo ln -sf "$DEPLOY_VHOST_PATH" /etc/apache2/sites-enabled/heron-cms-proxy.conf
+fi
+
+if [ -x "$DEPLOY_APACHE_CTL" ]; then
   echo "--- Apache configtest ---"
-  sudo /opt/bitnami/apache/bin/apachectl configtest || {
+  sudo "$DEPLOY_APACHE_CTL" configtest || {
     echo "Apache config test failed. Last 30 lines of error log:"
-    sudo tail -30 /opt/bitnami/apache/logs/error_log 2>/dev/null || sudo tail -30 /var/log/apache2/error.log 2>/dev/null || true
+    sudo tail -30 "$DEPLOY_APACHE_ERROR_LOG" 2>/dev/null || true
     exit 1
   }
 fi
-if [ -x /opt/bitnami/ctlscript.sh ]; then
-  sudo /opt/bitnami/ctlscript.sh restart apache || {
-    echo "Apache restart failed. Error log:"
-    sudo tail -50 /opt/bitnami/apache/logs/error_log 2>/dev/null || sudo journalctl -u bitnami.apache.service -n 30 --no-pager 2>/dev/null || true
-    exit 1
-  }
-else
-  sudo systemctl restart apache2 2>/dev/null || sudo systemctl restart httpd 2>/dev/null || true
-fi
-echo "✓ Apache proxy configured (80 + 443 -> 3000)"
+
+deploy_runtime_restart_apache
+echo "✓ Apache proxy configured (80 + 443 -> 3000, $DEPLOY_VENDOR)"
 
 if [ -n "${LETSENCRYPT_EMAIL:-}" ]; then
   if ! command -v certbot >/dev/null 2>&1; then
@@ -85,16 +96,16 @@ if [ -n "${LETSENCRYPT_EMAIL:-}" ]; then
     --non-interactive --agree-tos --email "$LETSENCRYPT_EMAIL" \
     --keep-until-expiring 2>/dev/null; then
     echo "✓ Let's Encrypt certificate obtained or already valid"
-    sudo sed -i "s|SSLCertificateFile .*|SSLCertificateFile $LE_CERT|" "$VHOST"
-    sudo sed -i "s|SSLCertificateKeyFile .*|SSLCertificateKeyFile $LE_KEY|" "$VHOST"
-    if [ -x /opt/bitnami/ctlscript.sh ]; then
-      sudo /opt/bitnami/ctlscript.sh restart apache
-    else
-      sudo systemctl restart apache2 2>/dev/null || sudo systemctl restart httpd 2>/dev/null || true
-    fi
+    sudo sed -i "s|SSLCertificateFile .*|SSLCertificateFile $LE_CERT|" "$DEPLOY_VHOST_PATH"
+    sudo sed -i "s|SSLCertificateKeyFile .*|SSLCertificateKeyFile $LE_KEY|" "$DEPLOY_VHOST_PATH"
+    deploy_runtime_restart_apache
   else
     echo "⚠ Certbot did not obtain a certificate (DNS may not point here yet); using existing or self-signed cert"
   fi
-  RENEW_HOOK='/opt/bitnami/ctlscript.sh restart apache 2>/dev/null || systemctl restart apache2'
+  if [ "$DEPLOY_VENDOR" = bitnami ]; then
+    RENEW_HOOK='/opt/bitnami/ctlscript.sh restart apache 2>/dev/null || systemctl restart apache2'
+  else
+    RENEW_HOOK='systemctl reload apache2'
+  fi
   (sudo crontab -l 2>/dev/null | grep -v certbot; echo "0 0,12 * * * certbot renew -q --deploy-hook \"$RENEW_HOOK\" 2>/dev/null") | sudo crontab - 2>/dev/null || true
 fi

--- a/heron/scripts/deploy-install-db-backup-cron.sh
+++ b/heron/scripts/deploy-install-db-backup-cron.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Install weekly SQLite → S3 backup cron (Sunday 03:15 UTC).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy-runtime.sh
+source "$SCRIPT_DIR/deploy-runtime.sh"
+deploy_runtime_detect
+
+APP_DIR="/opt/heron-cms"
+LOG_FILE="/var/log/heron-cms-db-backup.log"
+CRON_MARK="# heron-cms-db-backup"
+CRON_LINE="15 3 * * 0 cd ${APP_DIR} && set -a && [ -f .env ] && . ./.env && set +a && export PATH=\"${DEPLOY_NODE_BIN_DIR}:/usr/local/bin:/usr/bin:\$HOME/.local/bin:\$PATH\" && /usr/bin/env node scripts/backup-cms-db.cjs >> ${LOG_FILE} 2>&1 ${CRON_MARK}"
+
+sudo touch "$LOG_FILE"
+sudo chown "$DEPLOY_USER:$DEPLOY_USER" "$LOG_FILE"
+
+( crontab -l 2>/dev/null | grep -v "$CRON_MARK" || true
+  echo "$CRON_LINE"
+) | crontab -
+
+echo "✓ Weekly DB backup cron installed (Sun 03:15 UTC, retain \${CMS_DB_BACKUP_RETAIN_WEEKS:-8} weeks via backup-cms-db.cjs)"
+crontab -l | grep "$CRON_MARK" || true

--- a/heron/scripts/deploy-prepare-instance.sh
+++ b/heron/scripts/deploy-prepare-instance.sh
@@ -2,14 +2,22 @@
 # Prepare instance: wait for cloud-init/startup, ensure dirs and rsync.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy-runtime.sh
+source "$SCRIPT_DIR/deploy-runtime.sh"
+deploy_runtime_detect
+
 command -v cloud-init >/dev/null 2>&1 && sudo cloud-init status --wait >/dev/null 2>&1 || true
 for i in $(seq 1 36); do
-  if test -f /var/lib/heron-cms/.startup-done || test -x /opt/bitnami/node/bin/node 2>/dev/null; then
+  if deploy_runtime_node_ready; then
     break
   fi
   echo "Waiting for startup ($i/36)..."; sleep 10
 done
+
 sudo mkdir -p /opt/heron-cms /var/lib/heron-cms/data
-sudo chown -R bitnami:bitnami /opt/heron-cms /var/lib/heron-cms
+sudo chown -R "$DEPLOY_USER:$DEPLOY_USER" /opt/heron-cms /var/lib/heron-cms
 command -v rsync >/dev/null 2>&1 || { sudo apt-get update -y && sudo apt-get install -y rsync; }
-echo "✓ Instance ready"
+sudo touch /var/lib/heron-cms/.startup-done
+sudo chown "$DEPLOY_USER:$DEPLOY_USER" /var/lib/heron-cms/.startup-done
+echo "✓ Instance ready ($DEPLOY_VENDOR stack, user=$DEPLOY_USER)"

--- a/heron/scripts/deploy-restart-services.sh
+++ b/heron/scripts/deploy-restart-services.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Restart heron-cms via pm2 (install pm2 if needed, startup, restart/start, save).
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy-runtime.sh
+source "$SCRIPT_DIR/deploy-runtime.sh"
+deploy_runtime_detect
+
 cd /opt/heron-cms
-export PATH="/opt/bitnami/node/bin:/usr/local/bin:/usr/bin:$HOME/.local/bin:$PATH"
 
 if ! command -v pm2 >/dev/null 2>&1; then
   echo "Installing pm2..."
-  NPM_CMD="$(command -v npm 2>/dev/null || echo /opt/bitnami/node/bin/npm)"
+  NPM_CMD="$(command -v npm 2>/dev/null || echo "${DEPLOY_NODE_BIN_DIR}/npm")"
   export npm_config_prefix="$HOME/.local"
   mkdir -p "$HOME/.local/bin"
   "$NPM_CMD" install -g pm2
@@ -17,7 +22,8 @@ if [ ! -f .env ]; then
   exit 1
 fi
 set -a; . ./.env; set +a
-sudo -n env PATH=$PATH pm2 startup systemd -u bitnami --hp /home/bitnami 2>/dev/null || true
+
+sudo -n env PATH="$PATH" pm2 startup systemd -u "$DEPLOY_USER" --hp "$DEPLOY_HOME" 2>/dev/null || true
 
 if pm2 show heron-cms > /dev/null 2>&1; then
   pm2 restart heron-cms --update-env
@@ -25,4 +31,4 @@ else
   pm2 start server.js --name heron-cms
 fi
 pm2 save
-echo "✓ Services running"
+echo "✓ Services running ($DEPLOY_VENDOR stack)"

--- a/heron/scripts/deploy-runtime.sh
+++ b/heron/scripts/deploy-runtime.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Detect Bitnami vs Lightsail-packaged Node.js stack and export deploy paths.
+# Source from other deploy scripts: source "$(dirname "$0")/deploy-runtime.sh" && deploy_runtime_detect
+set -euo pipefail
+
+deploy_runtime_detect() {
+  if [ -x /opt/bitnami/node/bin/node ]; then
+    DEPLOY_VENDOR=bitnami
+    DEPLOY_USER="${LIGHTSAIL_DEPLOY_USER:-bitnami}"
+    DEPLOY_HOME="${DEPLOY_HOME:-/home/bitnami}"
+    DEPLOY_NODE_BIN_DIR=/opt/bitnami/node/bin
+    DEPLOY_VHOST_PATH=/opt/bitnami/apache/conf/vhosts/heron-cms-proxy.conf
+    DEPLOY_APACHE_CTL=/opt/bitnami/apache/bin/apachectl
+    DEPLOY_APACHE_RESTART=(sudo /opt/bitnami/ctlscript.sh restart apache)
+    DEPLOY_APACHE_CERT_DIR=/opt/bitnami/apache/conf/bitnami/certs
+    DEPLOY_APACHE_ERROR_LOG=/opt/bitnami/apache/logs/error_log
+  else
+    DEPLOY_VENDOR=lightsail
+    DEPLOY_USER="${LIGHTSAIL_DEPLOY_USER:-ubuntu}"
+    DEPLOY_HOME="${DEPLOY_HOME:-/home/ubuntu}"
+    if command -v node >/dev/null 2>&1; then
+      DEPLOY_NODE_BIN_DIR="$(dirname "$(command -v node)")"
+    else
+      DEPLOY_NODE_BIN_DIR=/usr/bin
+    fi
+    DEPLOY_VHOST_PATH=/etc/apache2/sites-available/heron-cms-proxy.conf
+    DEPLOY_APACHE_CTL=/usr/sbin/apache2ctl
+    DEPLOY_APACHE_RESTART=(sudo systemctl reload apache2)
+    DEPLOY_APACHE_CERT_DIR=/etc/ssl/heron-cms
+    DEPLOY_APACHE_ERROR_LOG=/var/log/apache2/error.log
+  fi
+
+  export DEPLOY_VENDOR DEPLOY_USER DEPLOY_HOME DEPLOY_NODE_BIN_DIR
+  export DEPLOY_VHOST_PATH DEPLOY_APACHE_CTL DEPLOY_APACHE_CERT_DIR DEPLOY_APACHE_ERROR_LOG
+  export PATH="${DEPLOY_NODE_BIN_DIR}:/usr/local/bin:/usr/bin:${HOME}/.local/bin:${PATH}"
+}
+
+deploy_runtime_node_ready() {
+  if [ -f /var/lib/heron-cms/.startup-done ]; then
+    return 0
+  fi
+  if [ -x "${DEPLOY_NODE_BIN_DIR:-/usr/bin}/node" ] 2>/dev/null || command -v node >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+deploy_runtime_restart_apache() {
+  if [ "$DEPLOY_VENDOR" = bitnami ] && [ -x /opt/bitnami/ctlscript.sh ]; then
+    sudo /opt/bitnami/ctlscript.sh restart apache
+    return
+  fi
+  if [ "$DEPLOY_VENDOR" = lightsail ]; then
+    sudo a2enmod proxy proxy_http ssl rewrite headers 2>/dev/null || true
+    sudo a2ensite heron-cms-proxy.conf 2>/dev/null || true
+    sudo "${DEPLOY_APACHE_CTL}" configtest
+    sudo systemctl reload apache2
+    return
+  fi
+  sudo systemctl restart apache2 2>/dev/null || sudo systemctl restart httpd 2>/dev/null || true
+}

--- a/heron/services/settings.ts
+++ b/heron/services/settings.ts
@@ -5,8 +5,7 @@ import { unstable_cache, revalidateTag } from "next/cache";
 
 function invalidateSettingsCache() {
     try {
-        // Next.js 15.5+: prefer profile "max" (stale-while-revalidate) in route handlers.
-        revalidateTag("settings", "max");
+        revalidateTag("settings");
     } catch (err) {
         console.error("Failed to revalidate settings cache:", err);
     }

--- a/infra/lightsail-cms.yaml
+++ b/infra/lightsail-cms.yaml
@@ -8,7 +8,10 @@ Parameters:
   LightsailBlueprintId:
     Type: String
     Default: nodejs
-    Description: "Bitnami Node.js blueprint. Run aws lightsail get-blueprints to list."
+    Description: >
+      Lightsail Node.js blueprint (AWS-packaged, not Bitnami). Run
+      `aws lightsail get-blueprints` and pick the active Node.js app blueprint
+      whose vendor is Lightsail. Changing this on an existing instance replaces the VM.
   LightsailBundleId:
     Type: String
     Default: nano_3_0
@@ -95,10 +98,18 @@ Resources:
         #!/bin/bash
         set -euo pipefail
         export DEBIAN_FRONTEND=noninteractive
-        echo "[startup] Creating app and data directories..."
+        if id -u ubuntu >/dev/null 2>&1; then
+          DEPLOY_USER=ubuntu
+        elif id -u bitnami >/dev/null 2>&1; then
+          DEPLOY_USER=bitnami
+        else
+          DEPLOY_USER=root
+        fi
+        echo "[startup] Creating app and data directories (user=$DEPLOY_USER)..."
         mkdir -p /opt/heron-cms /var/lib/heron-cms/data
-        chown -R bitnami:bitnami /opt/heron-cms /var/lib/heron-cms
+        chown -R "$DEPLOY_USER:$DEPLOY_USER" /opt/heron-cms /var/lib/heron-cms
         touch /var/lib/heron-cms/.startup-done
+        chown "$DEPLOY_USER:$DEPLOY_USER" /var/lib/heron-cms/.startup-done
         echo "[startup] Installing utilities..."
         apt-get update -y 2>/dev/null || true
         apt-get install -y rsync git unzip jq 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Adds `deploy-runtime.sh` to auto-detect **Bitnami** vs **Lightsail** Node.js stacks (Apache paths, SSH user, Node binary).
- Updates deploy scripts and GitHub Actions for **rsync + pm2** on nano instances—no Docker on the server.
- CI runs `npm rebuild better-sqlite3` after build so native modules match the Linux VM.
- Documents migration off deprecated Bitnami blueprint in `docs/DEPLOY_MIGRATION.md`.
- CloudFormation userdata picks `ubuntu` or `bitnami` at first boot; blueprint parameter documents Lightsail Node.js.

## Why

Bitnami Lightsail Node.js blueprints are deprecated (Nov 2026). We keep the same deploy model (your app via CI) on AWS’s maintained Node.js blueprint.

## Operator actions after merge

1. Create new Lightsail **Node.js** instance (vendor **Lightsail**).
2. Rsync `/var/lib/heron-cms/data` from old host.
3. Set GitHub secret `LIGHTSAIL_SSH_USER` to `ubuntu`.
4. Reattach static IP / run deploy workflow.
5. Decommission old Bitnami instance.

Until cutover, existing prod keeps working (workflow default SSH user remains `bitnami`).

## Test plan

- [x] `npm test` in `heron` (206 tests)
- [ ] PR Check workflow (lint, typecheck, build, Playwright)
- [ ] After merge: deploy workflow on staging/new instance with `LIGHTSAIL_SSH_USER=ubuntu`
- [ ] Verify HTTPS, admin login, image upload, DB migrations


Made with [Cursor](https://cursor.com)